### PR TITLE
adding CanvasTexture.js to fix export button

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,8 @@
   <script src="js/threefab/Ui.js"></script>
   <script src="js/threefab/Toolbox.js"></script>
   
+  <script src="js/threefab/textures/CanvasTexture.js"></script>
+  
   <script src="js/App.js"></script>
 
   <!-- Prompt IE 6 users to install Chrome Frame. Remove this if you want to support IE 6.


### PR DESCRIPTION
Adressing issue #23 - Can't export with threefab

As jterrace suggested, adding the script tag
    js/threefab/textures/CanvasTexture.js
to index.html gave some meaning to the export button
